### PR TITLE
feat: set up ESLint for TypeScript code quality

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,25 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+.cache/
+.clarinet/
+
+# Test files (Deno-based, use Clarinet's own checking)
+tests/
+
+# Frontend build
+frontend/dist/
+frontend/build/
+
+# Settings
+settings/
+
+# Clarity contracts (not TypeScript/JavaScript)
+*.clar
+
+# Config files
+*.config.js
+*.config.ts

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,56 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2022: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    project: './tsconfig.json',
+  },
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+    'prettier',
+  ],
+  ignorePatterns: [
+    'node_modules',
+    'dist',
+    'build',
+    '.cache',
+    '.clarinet',
+    'tests',
+    'frontend/dist',
+    'frontend/build',
+    '*.clar',
+    'settings',
+  ],
+  rules: {
+    // TypeScript specific rules
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'warn',
+
+    // General code quality rules
+    'no-console': ['warn', { allow: ['warn', 'error'] }],
+    'prefer-const': 'error',
+    'no-var': 'error',
+    'object-shorthand': 'error',
+    'quote-props': ['error', 'as-needed'],
+
+    // Prettier integration
+    'prettier/prettier': 'error',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "frontend:build": "cd frontend && npm run build",
     "frontend:preview": "cd frontend && npm run preview",
     "dev": "clarinet integrate",
-    "build": "npm run type-check && npm run check && npm run test",
+    "build": "npm run type-check && npm run lint && npm run check && npm run test",
     "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write \"**/*.{ts,tsx,clar,md,json}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,clar,md,json}\"",
     "prepare": "husky install"
@@ -38,8 +39,12 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.10.0",
+    "@typescript-eslint/eslint-plugin": "^6.15.0",
+    "@typescript-eslint/parser": "^6.15.0",
     "concurrently": "^8.2.2",
     "eslint": "^8.55.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.0.1",
     "husky": "^8.0.3",
     "prettier": "^3.1.1",
     "typescript": "^5.6.0"


### PR DESCRIPTION
- Add .eslintrc.cjs with TypeScript ESLint configuration
- Install @typescript-eslint/parser and @typescript-eslint/eslint-plugin
- Configure Prettier integration to avoid conflicts
- Add .eslintignore to exclude non-TS files and build outputs
- Add lint:fix script for automatic fixes
- Integrate linting into build process
- Use .cjs format for ESLint config (appropriate for ES module projects)

All TypeScript code now enforces consistent style and quality rules.

closes #5 