### PR TITLE
feat: set up Husky pre-commit hooks with lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Run lint-staged on staged files
+npx lint-staged
+
+# Run TypeScript type checking
+npm run type-check

--- a/package.json
+++ b/package.json
@@ -46,8 +46,25 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
     "husky": "^8.0.3",
+    "lint-staged": "^15.2.0",
     "prettier": "^3.1.1",
     "typescript": "^5.6.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{js,jsx,cjs,mjs}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md}": [
+      "prettier --write"
+    ],
+    "*.clar": [
+      "prettier --write"
+    ]
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
- Add lint-staged for efficient staged file checking
- Configure pre-commit hook to run ESLint and Prettier
- Add TypeScript type checking to pre-commit
- Auto-fix linting and formatting issues on commit
- Improve code quality gates before commits enter repository

Pre-commit hook now ensures code quality automatically.
closes #7 