### PR TITLE
feat: add validate-principal helper function

### DIFF
--- a/contracts/stacksend-escrow.clar
+++ b/contracts/stacksend-escrow.clar
@@ -82,7 +82,7 @@
 
     ;; Validations
     (asserts! (not (var-get contract-paused)) err-contract-paused)
-    (asserts! (not (is-eq recipient tx-sender)) err-invalid-recipient)
+    (try! (validate-principal recipient false))
     (asserts! (> target-amount u0) err-invalid-amount)
     (asserts! (> deadline current-time) err-invalid-deadline)
 
@@ -298,6 +298,18 @@
 )
 
 ;; Private Functions
+
+;; Helper function to validate principal addresses
+;; @param principal-to-check: The principal to validate
+;; @param allow-self: Whether tx-sender is allowed as the principal
+;; @returns: (ok true) if valid, error otherwise
+(define-private (validate-principal (principal-to-check principal) (allow-self bool))
+  (begin
+    ;; Check if principal is tx-sender when not allowed
+    (asserts! (or allow-self (not (is-eq principal-to-check tx-sender))) err-invalid-recipient)
+    (ok true)
+  )
+)
 
 ;; Helper function to refund a single contributor
 ;; @param contributor: The principal to refund


### PR DESCRIPTION
Created reusable helper function for principal validation:
- Validates that a principal is not tx-sender when required
- Takes allow-self parameter for flexibility
- Returns meaningful error (err-invalid-recipient)
- Added comprehensive inline documentation

Refactored create-remittance to use the new helper:
- Replaced manual validation with validate-principal call
- Maintains same validation behavior
- Improves code reusability and maintainability

Testing:
- Existing test "Fails when recipient is creator" validates the helper
- Test still passes with new implementation
- No new tests needed as functionality is tested indirectly

This helper will be reused across future functions that need principal validation (contribute-by-phone, etc.).
closes #23 