### PR TITLE
feat: add is-valid-string-length helper function

### DIFF
--- a/contracts/stacksend-escrow.clar
+++ b/contracts/stacksend-escrow.clar
@@ -351,6 +351,19 @@
   )
 )
 
+;; Helper function to validate string length
+;; @param length: The length to validate
+;; @param min-length: Minimum acceptable length
+;; @param max-length: Maximum acceptable length
+;; @returns: (ok true) if valid, error otherwise
+(define-private (is-valid-string-length (length uint) (min-length uint) (max-length uint))
+  (begin
+    (asserts! (>= length min-length) err-invalid-description)
+    (asserts! (<= length max-length) err-invalid-description)
+    (ok true)
+  )
+)
+
 ;; Helper function to validate description strings
 ;; @param description: The description to validate
 ;; @returns: (ok true) if valid, error otherwise


### PR DESCRIPTION
Add a generic helper function to validate string lengths for various string-ascii types throughout the contract. This provides reusable validation for checking if a string length falls within acceptable bounds.

closes #34 